### PR TITLE
Prevent Stats from stretching

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
             stats.domElement.style.position = 'absolute';
             stats.domElement.style.right = '0px';
             stats.domElement.style.bottom = '0px';
-
+            stats.domElement.style.left = '';
+            stats.domElement.style.top = '';
+            
             document.body.appendChild(stats.domElement);
             document.body.appendChild(renderer.view);
 


### PR DESCRIPTION
Stats is spreading all over the screen hence blocking mouse events on canvas.
Not that mandatory, but on first time developers might think the problem is somewhere else