### PR TITLE
Removes postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/pixijs/pixi-lights/issues"
   },
   "scripts": {
-    "postinstall": "npm run copy",
     "clean": "rimraf lib/* docs/*",
     "test": "npm run build",
     "prebuild": "npm run clean",
@@ -31,7 +30,7 @@
     "dev": "http-server . -o",
     "postversion": "npm run build",
     "postpublish": "npm run deploy",
-    "predeploy": "npm run docs",
+    "predeploy": "npm run copy",
     "copy": "copyfiles -f \"node_modules/{pixi.js,pixi-layers}/dist/*.{js,map}\" demo/lib",
     "deploy": "gh-pages -d . -s \"{demo,docs,lib}/**\"",
     "start": "parallelshell \"npm run watch\" \"npm run dev\""


### PR DESCRIPTION
Fixes #23 

This makes sure that "copyfiles" dependency isn't required in production.